### PR TITLE
Use SSL DEFAULT VERSION for curl Authentication

### DIFF
--- a/V5/Api/Authentication.php
+++ b/V5/Api/Authentication.php
@@ -224,7 +224,6 @@ class Authentication
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_POSTFIELDS => http_build_query($data),
             CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_SSLVERSION => 7 // Force requests to use TLS 1.3,
         ];
 
         $curl = curl_init(static::URL);


### PR DESCRIPTION
It seem's that CURLOPT_SSLVERSION => 7 (TLS 1.3) is not supports by HelloAsso (since few days)